### PR TITLE
Include HTML in the JSON output

### DIFF
--- a/packages/cli/src/mdt2json.ts
+++ b/packages/cli/src/mdt2json.ts
@@ -13,6 +13,7 @@ import fs from "node:fs";
 		.option("-o, --out <out>", "output directory")
 		.option("-l, --layout <layout>", "layout of json output", "SoA")
 		.option("-m, --minify", "minify json output")
+		.option("--include-html", "include HTML content from table cells in output")
 		.parse(process.argv);
 
 	const opts = program.opts();
@@ -52,6 +53,8 @@ import fs from "node:fs";
 
 	// biome-ignore lint/complexity/noUselessTernary: <explanation>
 	const minify = opts.minify ? true : false;
+	// biome-ignore lint/complexity/noUselessTernary: <explanation>
+	const includeHtml = opts.includeHtml ? true : false;
 
 	// check if file or dir is provided
 	if (opts.file) {
@@ -62,6 +65,7 @@ import fs from "node:fs";
 				markdownString: fs.readFileSync(opts.file, { encoding: "utf-8" }),
 				layout,
 				minify,
+				includeHtml,
 			});
 			fs.writeFileSync(opts.outFile, transpiler.transform());
 		}
@@ -90,6 +94,7 @@ import fs from "node:fs";
 					markdownString,
 					layout,
 					minify,
+					includeHtml,
 				});
 				fs.writeFileSync(`${opts.out}/${outFile}`, transpiler.transform());
 			}

--- a/packages/lib/tests/sample/test2_html_in.md
+++ b/packages/lib/tests/sample/test2_html_in.md
@@ -1,0 +1,4 @@
+| Header1                                   | Header2           |
+| ----------------------------------------- | ----------------- |
+| <a href="https://example.com">Example</a> | <h2>Heading2</h2> |
+| <p>Paragraph</p>                          | <em>Italic</em>   |

--- a/packages/lib/tests/sample/test2_html_out_disabled.md
+++ b/packages/lib/tests/sample/test2_html_out_disabled.md
@@ -1,0 +1,12 @@
+```json
+{
+    "Header1": [
+        "Example",
+        "Paragraph"
+    ],
+    "Header2": [
+        "Heading2",
+        "Italic"
+    ]
+}
+```

--- a/packages/lib/tests/sample/test2_html_out_enabled.md
+++ b/packages/lib/tests/sample/test2_html_out_enabled.md
@@ -1,0 +1,12 @@
+```json
+{
+    "Header1": [
+        "<a href=\"https://example.com\">Example</a>",
+        "<p>Paragraph</p>"
+    ],
+    "Header2": [
+        "<h2>Heading2</h2>",
+        "<em>Italic</em>"
+    ]
+}
+```

--- a/packages/lib/tests/transpiler.test.ts
+++ b/packages/lib/tests/transpiler.test.ts
@@ -2,21 +2,12 @@ import fs from "node:fs";
 import { JsonLayout, MarkdownTable2Json } from "../src/mdt2json";
 
 describe("transpiler", () => {
-	// generate array of numbers from 1 to 1
-	const files = Array.from(Array(1).keys()).map((x) => {
-		const inMd = fs.readFileSync(`tests/sample/test${x + 1}_in.md`, { encoding: "utf-8" });
-		const outAoS = fs.readFileSync(`tests/sample/test${x + 1}aos_out.md`, { encoding: "utf-8" });
-		const outSoA = fs.readFileSync(`tests/sample/test${x + 1}soa_out.md`, { encoding: "utf-8" });
+	describe("simple tables", () => {
+		const inMd = fs.readFileSync("tests/sample/test1_in.md", { encoding: "utf-8" });
+		const outAoS = fs.readFileSync("tests/sample/test1aos_out.md", { encoding: "utf-8" });
+		const outSoA = fs.readFileSync("tests/sample/test1soa_out.md", { encoding: "utf-8" });
 
-		return {
-			inMd,
-			outAoS,
-			outSoA,
-		};
-	});
-
-	it("simple tables aos", () => {
-		for (const { inMd, outAoS } of files) {
+		it("simple tables aos", () => {
 			const transpiler = new MarkdownTable2Json({
 				markdownString: inMd,
 				layout: JsonLayout.AoS,
@@ -24,11 +15,9 @@ describe("transpiler", () => {
 			});
 
 			expect(transpiler.transform()).toBe(outAoS);
-		}
-	});
+		});
 
-	it("simple tables soa", () => {
-		for (const { inMd, outSoA } of files) {
+		it("simple tables soa", () => {
 			const transpilerSoA = new MarkdownTable2Json({
 				markdownString: inMd,
 				layout: JsonLayout.SoA,
@@ -36,6 +25,34 @@ describe("transpiler", () => {
 			});
 
 			expect(transpilerSoA.transform()).toBe(outSoA);
-		}
+		});
+	});
+
+	describe("include html", () => {
+		const inMd = fs.readFileSync("tests/sample/test2_html_in.md", { encoding: "utf-8" });
+
+		it("enabled", () => {
+			const out = fs.readFileSync("tests/sample/test2_html_out_enabled.md", { encoding: "utf-8" });
+
+			const transpiler = new MarkdownTable2Json({
+				markdownString: inMd,
+				minify: false,
+				includeHtml: true,
+			});
+
+			expect(transpiler.transform()).toBe(out);
+		});
+
+		it("disabled", () => {
+			const out = fs.readFileSync("tests/sample/test2_html_out_disabled.md", { encoding: "utf-8" });
+
+			const transpiler = new MarkdownTable2Json({
+				markdownString: inMd,
+				minify: false,
+				includeHtml: false,
+			});
+
+			expect(transpiler.transform()).toBe(out);
+		});
 	});
 });


### PR DESCRIPTION
Hi! 

My motivation: the markdown tables I wanna convert include `<a>` anchor elements, and I'd like to retain both the href and the link text in the output

I also added an `--includeHtml` cli argument which defaults to false (assuming the user does not care about the HTML content)

